### PR TITLE
feat: code of conduct page + styling changes

### DIFF
--- a/src/app/code-of-conduct/page.js
+++ b/src/app/code-of-conduct/page.js
@@ -2,14 +2,406 @@ import Container from "@/app/lib/components/primitives/Container";
 import Section from "@/app/lib/components/primitives/Section";
 import Subpage from "@/app/lib/components/templates/Subpage";
 import { createMetadata } from "../lib/utils/createMetadata";
+import Link from "../lib/components/primitives/Link";
 
-export const metadata = createMetadata({title: 'Code of Conduct'});
+export const metadata = createMetadata({ title: "Code of Conduct" });
 
 export default function CodeOfConduct() {
   return (
-    <Subpage title={'Code of Conduct'} subheading={'Policy Against Harassment at ACM Activities'}>
-      <Section title={'Test'} spacing={'bottom-only'}>
-     
+    <Subpage
+      title={"Code of Conduct"}
+      subheading={"Policy Against Harassment at ACM Activities"}
+    >
+      <Section
+        title={"Policy Against Harassment at ACM Activities"}
+        spacing={"bottom-only"}
+      >
+        <p>
+          The open exchange of ideas is central to the Association for Computing
+          Machinery's mission. This requires an environment that embraces
+          diversity and provides a safe, welcoming environment for all.
+        </p>
+        <p>This policy applies to all ACM activities, including:</p>
+        <ul>
+          <li>
+            Conferences, symposia, workshops, and events sponsored,
+            co-sponsored, or in cooperation with ACM any ACM SIG or Chapter or
+            any other ACM subunit;
+          </li>
+          <li>ACM member meetings;</li>
+          <li>
+            Exchanges among committees or other bodies associated with ACM
+            activities publications and communications sent through
+            communication channels associated with ACM, including social media.
+          </li>
+        </ul>
+      </Section>
+      <Section title={"Expected Behavior"} spacing={"bottom-only"}>
+        <p>
+          We expect all participants in ACM activities to abide by this policy
+          in all venues, including ancillary events and unofficial social
+          gatherings:
+        </p>
+        <ul>
+          <li>
+            Exercise consideration and respect in your speech and actions;
+          </li>
+          <li>
+            Refrain from demeaning, discriminatory, or harassing behavior and
+            speech;
+          </li>
+          <li>
+            Be mindful of your surroundings and of your fellow participants;
+          </li>
+          <li>
+            Alert community leaders if you notice a dangerous situation, someone
+            in distress, or violations of this policy, even if they seem
+            inconsequential.
+          </li>
+        </ul>
+      </Section>
+      <Section title={"Unacceptable Behavior"} spacing={"bottom-only"}>
+        <p>Unacceptable at any ACM activity is:</p>
+        <ul>
+          <li>
+            {`Abuse: Any action directed at an individual that (a) interferes
+            substantially with that person's participation; or (b) causes that
+            person to fear for his/her personal safety. This includes threats,
+            intimidation, bullying, stalking, or other types of abuse.`}
+          </li>
+          <li>
+            Discriminatory Harassment: Any conduct that discriminates or
+            denigrates an individual on the basis of race, ethnicity, religion,
+            citizenship, nationality, age, sexual or gender identity,
+            disability, or any other characteristic protected by law in the
+            location where the ACM activity takes place.
+          </li>
+          <li>
+            Sexual Harassment: Unwelcome sexual advances, requests for sexual
+            favors, or other verbal/physical conduct of a sexual nature.
+            Examples include (but are not limited to):
+            <ul>
+              <li>
+                Unwelcome advances or propositions, particularly when one
+                individual has authority over the other;
+              </li>
+              <li>Inappropriate touching of an individual's body;</li>
+              <li>
+                Degrading or humiliating comments about an individual's
+                appearance;
+              </li>
+              <li>
+                Using an activity-related communication channel to display or
+                distribute sexually explicit images or messages;
+              </li>
+            </ul>
+          </li>
+          <li>
+            Alert community leaders if you notice a dangerous situation, someone
+            in distress, or violations of this policy, even if they seem
+            inconsequential.
+          </li>
+        </ul>
+        <p>Unacceptable behaviors include, but are not limited to:</p>
+        <ul>
+          <li>
+            Intimidating, harassing, abusive discriminatory, derogatory, or
+            demeaning speech or actions by any participant in ACM activities, at
+            all related events and in one-on-one communications carried out in
+            the context of ACM activities;
+          </li>
+          <li>
+            Offensive, degrading, humiliating, harmful, or prejudicial verbal or
+            written comments or visual images related to gender, sexual
+            orientation, race, religion, disability, age, appearance, or other
+            personal characteristics;
+          </li>
+          <li>
+            Unwelcome sexual advances, requests for sexual favors. or other
+            verbal/physical conduct of a sexual nature;
+          </li>
+          <li>
+            Inappropriate or gratuitous use of nudity, sexual images, or
+            stereotyped images including using an activity related channel to
+            display or distribute sexually explicit or otherwise offensive or
+            discriminatory images or messages;
+          </li>
+          <li>Deliberate intimidation, stalking, or following;</li>
+          <li>Harassing photography or recording;</li>
+          <li>Sustained disruption of talks or other events;</li>
+          <li>Unwelcome and uninvited attention or contact;</li>
+          <li>Physical assault (including unwelcome touch or groping);</li>
+          <li>Real or implied threat of physical harm;</li>
+          <li>
+            Real or implied threat of professional or financial damage or harm.
+          </li>
+        </ul>
+        <p>
+          Harassment can occur when there is no deliberate intention to offend.
+          Be careful in the words that you choose. Harassment committed in a
+          joking manner or disguised as a compliment still constitutes
+          unacceptable behavior. Remember that sexist, racist, and other
+          exclusionary jokes can be offensive to those around you.
+        </p>
+      </Section>
+      <Section
+        title={"Consequences of Unacceptable Behavior"}
+        spacing={"bottom-only"}
+      >
+        <p>
+          If a participant in an ACM activity engages in prohibited behavior,
+          ACM reserves the right to take any action ACM deems appropriate. ACM
+          reserves the right to:
+        </p>
+        <ul>
+          <li>
+            Remove an individual from any ACM activity without warning or
+            refund;
+          </li>
+          <li>
+            Prohibit an individual from participating in future ACM activities;
+          </li>
+          <li>Exclude an individual from ACM leadership positions;</li>
+          <li>
+            Exclude any individual from deriving other benefits from ACM
+            activities;
+          </li>
+          <li>Suspend or terminate membership in ACM.</li>
+        </ul>
+        <p>
+          Such sanctions may be applied regardless of whether or not the
+          offender is a member of ACM.
+        </p>
+        <p>
+          Appropriate sanctions also will be taken toward any individual who
+          knowingly makes a false allegation of harassment.
+        </p>
+      </Section>
+      <Section
+        title={"How to Report Unacceptable Behavior"}
+        spacing={"bottom-only"}
+      >
+        <p>
+          Any individual who experiences harassment (as described above) at any
+          ACM activity should follow the{" "}
+          <Link
+            href={
+              "https://www.acm.org/about-acm/reporting-unacceptable-behavior"
+            }
+          >
+            Procedures for Reporting Unacceptable Behavior.
+          </Link>
+        </p>
+        <p>
+          This policy applies only to unacceptable behavior at ACM activities.
+          Complaints regarding other issues should be addressed as described
+          under the applicable ACM policy. For example, complaints about papers
+          and publications should be made under either{" "}
+          <Link
+            href={
+              "https://www.acm.org/about-acm/acm-code-of-ethics-and-professional-conduct"
+            }
+          >
+            ACM's Code of Ethics and Professional Conduct
+          </Link>{" "}
+          or{" "}
+          <Link href={"https://www.acm.org/publications/policies/plagiarism"}>
+            its Plagiarism Policy.
+          </Link>
+        </p>
+        <h2 id="addressing-grievances">Addressing Grievances</h2>
+        <p>
+          If you feel you have been falsely or unfairly accused of violating
+          this Policy Against Harassment at ACM Activities you should notify{" "}
+          <Link href={"mailto:advocate@acm.org"}>advocate@acm.org</Link> with a
+          concise description of your grievance. Your grievance will be
+          thoroughly investigated. Your grievance will be handled in accordance
+          with our existing procedures.
+        </p>
+      </Section>
+      <Section title={"Warnings and Disclaimers"} spacing={"bottom-only"}>
+        <p>
+          This Policy Against Harassment at ACM Activities is not intended to
+          limit open discussion of the merits of particular work or issues
+          presented at ACM events. It applies only to behavior at ACM events and
+          activities.
+        </p>
+        <p>
+          ACM assumes no liability or responsibility for the actions of any
+          member or other activity participant.
+        </p>
+        <p>
+          ACM is not responsible for protecting the safety of members or
+          participants in ACM activities. Any individual who feels his/her
+          safety is at risk due to harassment or for any other reason is
+          encouraged to take appropriate steps to ensure personal safety.
+        </p>
+        <p>
+          This Policy supersedes any policy or guidelines concerning harassment
+          issued by ACM, or one of its Special Interest Groups, or any other ACM
+          sub-unit.
+        </p>
+        <p>
+          There may be situations (such as those involving Title IX issues in
+          the United States and venue- or employer-specific policies) where an
+          on-site person who is informed of harassment will be under an
+          obligation to file a report with an individual or organization outside
+          of ACM.
+        </p>
+      </Section>
+      <Section
+        title={"Reporting Unacceptable Behavior at ACM Activities"}
+        spacing={"bottom-only"}
+      >
+        <p>
+          The first priority should always be personal safety. An individual who
+          experiences harassment should take immediate action if needed to
+          remain safe.
+        </p>
+        <p>
+          The procedures here describe how to report unacceptable behavior at
+          ACM activities.{" "}
+          <Link
+            href={"https://www.acm.org/about-acm/policy-against-harassment"}
+          >
+            The Policy Against Harassment at ACM Activities
+          </Link>{" "}
+          describes actions that constitute harassment.
+        </p>
+      </Section>
+      <Section
+        title={
+          "What Should I Do If I Experience or Witness Unacceptable Behavior?"
+        }
+        spacing={"bottom-only"}
+      >
+        <p>
+          In the event of unacceptable behavior, you may wish to inform a person
+          in authority. Those in authority to act in these cases include the
+          event chair, a SIG leader, an onsite ACM staff member, and other event
+          organizers who have been designated to handle such complaints at this
+          activity. These individuals can provide information about the process
+          for handling complaints or handling immediate onsite needs.
+        </p>
+        <p>
+          <i>
+            Note that there may be cases (such as those involving Title IX
+            issues in the United States and venue- or employer-specific
+            policies) where an on-site person who is informed of harassment will
+            be required to file a complaint.
+          </i>
+        </p>
+        <p>
+          Any investigation or further action requires that a written
+          communication be made to ACM. Report the incident using the{" "}
+          <Link href={"https://services.acm.org/harass/harass.cfm"}>
+            form for Reporting Violations of the ACM Policy Against Harassment.
+          </Link>{" "}
+          Prompt reporting is critical so that ACM can take action to stop the
+          conduct before it is repeated. All reports will be followed up
+          promptly, with further investigation conducted where needed to confirm
+          facts or resolve disputed facts. In conducting its investigations, ACM
+          will strive to keep the identity of the individual making the report
+          as confidential as possible beyond the investigation.
+        </p>
+        <p>
+          ACM prohibits any threats or acts of retaliation against individuals
+          who report unacceptable behavior or provide information in connection
+          with a report by another individual. ACM considers a threat or act of
+          retaliation to be as serious an offense as harassment itself and will
+          handle reports of retaliation accordingly.
+        </p>
+      </Section>
+      <Section
+        title={"Reporting Unacceptable Behavior at ACM Activities"}
+        spacing={"bottom-only"}
+      >
+        <p>
+          The first priority should always be personal safety. An individual who
+          experiences harassment should take immediate action if needed to
+          remain safe.
+        </p>
+        <p>
+          The procedures here describe how to report unacceptable behavior at
+          ACM activities.{" "}
+          <Link
+            href={"https://www.acm.org/about-acm/policy-against-harassment"}
+          >
+            The Policy Against Harassment at ACM Activities
+          </Link>{" "}
+          describes actions that constitute harassment.
+        </p>
+      </Section>
+      <Section
+        title={"What Should I Do as a Person in Authority?"}
+        spacing={"bottom-only"}
+      >
+        <p>
+          As a person in authority at an ACM event, you need to understand how
+          to handle possible incidents. Those in authority include the event
+          chair, a SIG leader, an onsite ACM staff member, and other event
+          organizers who have been designated to handle such complaints at this
+          activity.
+        </p>
+
+        <p>
+          Your primary role as a person in authority is to (a) lend a
+          sympathetic ear and (b) explain procedures for reporting unacceptable
+          behavior if a person wishes to pursue further action. In general, you
+          should not attempt to mediate or resolve complaints informally.
+        </p>
+        <p>
+          If the situation appears to be an emergency (e.g., requiring medical
+          assistance or if there has been an overt threat of violence), you
+          should use judgment and common sense. Never presume, however, that an
+          individual would welcome your involvement. Instead, tell the person to
+          take any step he/she feels is needed to ensure personal safety.
+        </p>
+        <p>
+          If the immediate emergency extends to more than one individual, event
+          organizers may need to take stronger actions, such as addressing the
+          event attendees as a whole, barring further event attendance and
+          participation by specific attendees, or imposing requirements on an
+          attendee's further participation. Such decisions should be kept as
+          minimally intrusive as possible, and must be made with the awareness
+          that an allegation is not the same as a determination of guilt. Any
+          post-event investigations, sanctions, or other actions should be
+          handled by using the{" "}
+          <Link href={"https://services.acm.org/harass/harass.cfm"}>
+            form for Reporting Violations of the ACM Policy Against Harassment.
+          </Link>{" "}
+        </p>
+        <p>
+          If an event uses contractors, the event organizers should make sure
+          the contractors are told to report any incident to a person in
+          authority rather than dealing with it themselves.
+        </p>
+      </Section>
+      <Section
+        title={"What Enforcement Procedures Will be Followed?"}
+        spacing={"bottom-only"}
+      >
+        <p>
+          When receiving a report of unacceptable behavior, ACM's President,
+          CEO, or COO will review and direct appropriate follow up. In
+          consultation with the Chair of ACM's Committee on Professional Ethics
+          (COPE), the executive will also make a recommendation to COPE
+          regarding resolution. COPE will make a final, binding decision
+          regarding whether ACM's policy has been violated and the consequences
+          of any such violation.
+        </p>
+        <p>
+          The Committee may take actions including, but not limited to,
+          suspension or termination of membership in ACM, exclusion from ACM
+          leadership positions, exclusion from participating in future ACM
+          events, and/or exclusion from deriving other benefits from ACM
+          activities. Such actions may be applied regardless of whether or not
+          the offender is a member of ACM.
+        </p>
+        <p>
+          The same actions may be taken toward any individual who engages in
+          retaliation or who knowingly makes a false allegation of harassment.
+        </p>
       </Section>
     </Subpage>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,19 +3,47 @@
 @tailwind utilities;
 
 @layer base {
-    h1, .h1 {
-        @apply font-bold text-2xl md:text-3xl xl:text-4xl
-    }
-    h2, .h2 {
-        @apply font-bold text-xl md:text-2xl xl:text-3xl 
-    }
-    h3, .h3 {
-        @apply font-normal text-lg md:text-xl xl:text-2xl 
-    }
+  h1,
+  .h1 {
+    @apply font-bold text-2xl md:text-3xl xl:text-4xl;
+  }
+  h2,
+  .h2 {
+    @apply font-bold text-xl md:text-2xl xl:text-3xl;
+  }
+  h3,
+  .h3 {
+    @apply font-normal text-lg md:text-xl xl:text-2xl;
+  }
+
+  /* 
+  ** Applies to all things within a "section" component.
+  ** This is to help create some defaults that look good 
+  ** and that the user gets for free.
+  */
+
+  section h2, section h3, section h4 {
+    @apply my-4
+  }
+  section p:not(:first-child) {
+    @apply mt-4;
+  }
+  section a {
+    @apply text-link-underline-red;
+  }
+  section li {
+    @apply ml-8 list-disc mb-2;
+  }
+  section li:first-child {
+    @apply mt-4;
+  }
+  section li li {
+    @apply list-circle;
+  }
 }
 
 :root {
-    --background-grey: #2b2b2b;
-    --primary-light: #ffffff;
-    --primary-dark: #000000;
+  --background-grey: #2b2b2b;
+  --primary-light: #ffffff;
+  --primary-dark: #000000;
 }

--- a/src/app/lib/components/Banner.js
+++ b/src/app/lib/components/Banner.js
@@ -3,7 +3,7 @@ import Container from "./primitives/Container";
 
 export default function Banner({ heading, subheading }) {
     return (
-        <div className="h-[45vh] w-full relative overflow-hidden bg-hero-img bg-center bg-cover text-theme-off-white">
+        <div className="h-[45vh] w-full relative overflow-hidden bg-hero-img bg-top bg-cover text-theme-off-white">
             <Container className="z-[50] relative h-full flex flex-col gap-3 justify-end py-0 mt-4">
                 <h1 className="text-4xl md:text-6xl">{heading}</h1>
                 <p className="pb-12">{subheading}</p>

--- a/src/app/lib/components/primitives/Footer.js
+++ b/src/app/lib/components/primitives/Footer.js
@@ -28,7 +28,7 @@ export default function Footer() {
           </div>
           <div>
             <p className="text-2xl font-bold hidden xl:block text-right">All rights reserved</p>
-            <img className="mt-12 w-[200px] md:w-[40%] xl:w-auto " src="./assets/logos/a24-full-logo-grey.svg" alt="Assets 2024 Logo, displaying a lighthouse to the left and the words 'assets' in the middle."/>
+            <img className="mt-12 w-[200px] md:w-[40%] xl:w-auto " src="/assets/logos/a24-full-logo-grey.svg" alt="Assets 2024 Logo, displaying a lighthouse to the left and the words 'assets' in the middle."/>
           </div>
         </div>
       </Container>

--- a/src/app/lib/components/primitives/Section.js
+++ b/src/app/lib/components/primitives/Section.js
@@ -12,16 +12,16 @@ export default function Section({ title, children, className, spacing, id }) {
 
     switch (spacing) {
       case 'standard':
-        setSpacing = 'py-16 md:py-20'
+        setSpacing = 'py-16 md:py-18'
         break;
       case 'top-only':
-        setSpacing = 'pt-16 md:pt-20'
+        setSpacing = 'pt-16 md:pt-18'
         break;
       case 'bottom-only':
-        setSpacing = 'pb-16 md:pb-20'
+        setSpacing = 'pb-16 md:pb-18'
         break;
       default:
-        setSpacing = 'py-16 md:py-20'
+        setSpacing = 'py-16 md:py-18'
         break;
     }
     
@@ -31,7 +31,7 @@ export default function Section({ title, children, className, spacing, id }) {
   return (
     <section className={`${evalSpacing()} ${className}`}>
       <div className='mt-7 border-b-[2px] border-black'>
-        <h1  id={id ? id : generateID()}  className='flex flex-row justify-flex-start content-center gap-3 mb-6 max-w-[30ch]'><FaArrowRight aria-hidden className='mt-[.1rem]'/>{title}</h1>
+        <h1  id={id ? id : generateID()}  className='flex flex-row justify-flex-start content-center gap-3 mb-6 max-w-[30ch]'><FaArrowRight aria-hidden className='mt-[.1rem] min-w-[1em] aspect-square'/>{title}</h1>
       </div>
       <div className='mt-7'>
         {children}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,7 +6,7 @@ import Section from "./lib/components/primitives/Section";
 import { CONFERENCE_DATES } from "./lib/config/homepage.config";
 import { createMetadata } from "./lib/utils/createMetadata";
 
-export const metadata = createMetadata({title: 'Home'})
+export const metadata = createMetadata({ title: "Home" });
 export default function Home() {
   return (
     <>
@@ -14,26 +14,31 @@ export default function Home() {
         <Hero />
         <Container id="content">
           <Section title="ASSETS at a Glance" spacing={"top-only"}>
-            <div className="flex flex-col gap-y-4">
-              <p className="h3">{`The 26th International ACM SIGACCESS Conference on Computers and Accessibility.`}</p>
-              <p>{`The ASSETS conference is the premier forum for presenting research on the design, evaluation, use, and education related to computing for people with disabilities and older adults. For those in Europe and Oceania, ASSETS is rated as Core A — a designation for the top academic conferences that are "highly respected in a discipline area" (Core A; Top 16%).`}</p>
-              <p>
-                {`We invite high-quality original submissions on topics relevant to computing and accessibility. All contributions are peer-reviewed by an international Program Committee. Accepted papers and the abstracts for posters and demonstrations, experience reports, and the student research competition will be archived in the ACM Digital Library. Authors of selected papers will be invited to submit extended versions of their papers to a special issue of the`}{" "}
-                <Link
-                  href="https://dl.acm.org/journal/taccess"
-                  target="_blank"
-                  colour={"primary"}
-                >{`ACM Transactions on Accessible Computing (TACCESS)`}</Link>
-                .
-              </p>
-            </div>
+            {/* <div className="flex flex-row gap-x-12"> */}
+              {/* <div className="flex flex-col gap-y-4"> */}
+                <p className="h3">{`The 26th International ACM SIGACCESS Conference on Computers and Accessibility.`}</p>
+                <p>{`The ASSETS conference is the premier forum for presenting research on the design, evaluation, use, and education related to computing for people with disabilities and older adults. For those in Europe and Oceania, ASSETS is rated as Core A — a designation for the top academic conferences that are "highly respected in a discipline area" (Core A; Top 16%).`}</p>
+                <p>
+                  {`We invite high-quality original submissions on topics relevant to computing and accessibility. All contributions are peer-reviewed by an international Program Committee. Accepted papers and the abstracts for posters and demonstrations, experience reports, and the student research competition will be archived in the ACM Digital Library. Authors of selected papers will be invited to submit extended versions of their papers to a special issue of the`}{" "}
+                  <Link
+                    href="https://dl.acm.org/journal/taccess"
+                    target="_blank"
+                    colour={"primary"}
+                  >{`ACM Transactions on Accessible Computing (TACCESS)`}</Link>
+                  .
+                </p>
+              {/* </div> */}
+              {/* <div className="object-cover ">
+                <img className="aspect-[9/16] object-cover" src="/assets/assets23-img-2.jpg" />
+              </div> */}
+            {/* </div> */}
           </Section>
           <Section title="Important Dates" spacing={"standard"}>
             <p>
               <strong>All deadlines</strong> are 11:59 P.M. Anywhere on Earth
               (UTC -12:00).
             </p>
-            <DateList dates={null}/>
+            <DateList dates={null} />
           </Section>
         </Container>
       </main>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,32 +1,35 @@
 import plugin from "tailwindcss/plugin";
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    content: [
-        "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-        "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-        "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-    ],
-    theme: {
-        extend: {
-            colors: {
-                "theme-dark": "#2B2B2B",
-                "theme-off-white": "#D4D4D4",
-                "theme-red": "#592321",
-                "primary-text-light": "var(--primary-light)",
-                "primary-text-dark": "var(--primary-dark)",
-                "link-underline-red": "#a62929"
-            },
-            backgroundImage: {
-                "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-                "gradient-conic":
-                    "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
-                "hero-img": "url(../../public/assets/hero-background.jpg)",
-            },
-        },
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        "theme-dark": "#2B2B2B",
+        "theme-off-white": "#D4D4D4",
+        "theme-red": "#592321",
+        "primary-text-light": "var(--primary-light)",
+        "primary-text-dark": "var(--primary-dark)",
+        "link-underline-red": "#a62929",
+      },
+      listStyleType: {
+        circle: "circle",
+      },
+      backgroundImage: {
+        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
+        "gradient-conic":
+          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        "hero-img": "url(../../public/assets/hero-background.jpg)",
+      },
     },
-    plugins: [
-        plugin(function ({ addVariant }) {
-            addVariant("hoctive", ["&:hover", "&:focus", "&:active"]);
-        }),
-    ],
+  },
+  plugins: [
+    plugin(function ({ addVariant }) {
+      addVariant("hoctive", ["&:hover", "&:focus", "&:active"]);
+    }),
+  ],
 };


### PR DESCRIPTION
- feat: 💄 add new defaults for `<p>` + more:
   - Adds new default styling for any `<p>`, `<a>` and `<li>` tags within a page's content area  (`<Section/>`)

- feat: ✏️ add content for code of conduct
  - also fixes issues with the footer image

- fix: 💄 reduce spacing btwn sections
  - thought it was a little too much. + fixed issue where arrows would compress when there were multi-lines